### PR TITLE
Add catch-all route for unknown paths

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import OpenChat from './pages/OpenChat';
 import HRTools from './pages/HRTools';
 import Profile from './pages/Profile';
 import KnowledgeArticle from './pages/KnowledgeArticle';
+import NotFound from './pages/NotFound';
 
 // Import Font Awesome
 import '@fortawesome/fontawesome-free/css/all.min.css';
@@ -28,6 +29,7 @@ function App() {
             <Route path="/open-chat" element={<OpenChat />} />
             <Route path="/hr-tools" element={<HRTools />} />
             <Route path="/profile" element={<Profile />} />
+            <Route path="*" element={<NotFound />} />
           </Routes>
         </main>
         <Footer />

--- a/src/pages/NotFound.js
+++ b/src/pages/NotFound.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const NotFound = () => (
+  <section style={{ padding: '100px 0', textAlign: 'center' }}>
+    <div className="container">
+      <h1 style={{ fontSize: '3rem', marginBottom: '20px' }}>Page Not Found</h1>
+      <p style={{ marginBottom: '30px' }}>
+        The page you're looking for doesn't exist. It may have been moved or deleted.
+      </p>
+      <Link to="/" className="btn btn-primary">Go to Home</Link>
+    </div>
+  </section>
+);
+
+export default NotFound;


### PR DESCRIPTION
## Summary
- add a `NotFound` page component
- show the `NotFound` page for any unmatched URL

## Testing
- `npm test --silent`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889071c785c832e9e62dc913e6abf68